### PR TITLE
Feature/variable option lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/plotx/smart-contracts-L2.svg?branch=feature/predictFor)](https://travis-ci.org/plotx/smart-contracts-L2)
+[![Build Status](https://travis-ci.org/plotx/smart-contracts-L2.svg?branch=merge-finalDeployment)](https://travis-ci.org/plotx/smart-contracts-L2)
 
-[![Coverage Status](https://coveralls.io/repos/github/plotx/smart-contracts-L2/badge.svg?branch=feature/predictFor)](https://coveralls.io/github/plotx/smart-contracts-L2)
+[![Coverage Status](https://coveralls.io/repos/github/plotx/smart-contracts-L2/badge.svg?branch=merge-finalDeployment)](https://coveralls.io/github/plotx/smart-contracts-L2)
 
 <h1><a id="PLOTX"></a>PlotX SMART CONTRACTS</h1>
 <p>Smart contracts for PlotX - Curated prediction markets for crypto traders . https://plotx.io/.</p>

--- a/contracts/AllPlotMarkets_4.sol
+++ b/contracts/AllPlotMarkets_4.sol
@@ -26,6 +26,10 @@ contract AllPlotMarkets_4 is AllPlotMarkets_3 {
      */
     function _placeInitialPrediction(uint64 _marketId, address _msgSenderAddress, uint64 _initialLiquidity, uint64 _totalOptions) internal {
       uint256 _defaultAmount = (10**predictionDecimalMultiplier).mul(_initialLiquidity);
+      if(userData[_msgSenderAddress].marketsParticipated.length > maxPendingClaims) {
+        _withdrawReward(defaultMaxRecords, _msgSenderAddress);
+      }
+
       (uint _tokenLeft, uint _tokenReward) = getUserUnusedBalance(_msgSenderAddress);
       uint _balanceAvailable = _tokenLeft.add(_tokenReward);
       if(_balanceAvailable < _defaultAmount) {

--- a/contracts/AllPlotMarkets_4.sol
+++ b/contracts/AllPlotMarkets_4.sol
@@ -65,7 +65,6 @@ contract AllPlotMarkets_4 is AllPlotMarkets_3 {
         unusedBalance = _userData.unusedBalance;
         unusedBalance = unusedBalance.div(decimalMultiplier);
       }
-      require(_predictionStake <= unusedBalance); // Redundant check, can be removed
       _userData.unusedBalance = (unusedBalance.sub(_predictionStake)).mul(decimalMultiplier);
       _predictionStakePostDeduction = _deductFee(_marketId, _predictionStake, _msgSenderAddress);
       

--- a/contracts/AllPlotMarkets_4.sol
+++ b/contracts/AllPlotMarkets_4.sol
@@ -1,0 +1,74 @@
+/* Copyright (C) 2021 PlotX.io
+
+  This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/ */
+
+pragma solidity 0.5.7;
+
+import "./AllPlotMarkets_3.sol";
+
+contract AllPlotMarkets_4 is AllPlotMarkets_3 {
+
+    /**
+     * @dev Internal function to place initial prediction of the market creator
+     * @param _marketId Index of the market to place prediction
+     * @param _msgSenderAddress Address of the user who is placing the prediction
+     */
+    function _placeInitialPrediction(uint64 _marketId, address _msgSenderAddress, uint64 _initialLiquidity, uint64 _totalOptions) internal {
+      uint256 _defaultAmount = (10**predictionDecimalMultiplier).mul(_initialLiquidity);
+      (uint _tokenLeft, uint _tokenReward) = getUserUnusedBalance(_msgSenderAddress);
+      uint _balanceAvailable = _tokenLeft.add(_tokenReward);
+      if(_balanceAvailable < _defaultAmount) {
+        _deposit(_defaultAmount.sub(_balanceAvailable), _msgSenderAddress);
+      }
+      address _predictionToken = predictionToken;
+      uint64 _predictionAmount = _initialLiquidity/ _totalOptions;
+      for(uint i = 1;i < _totalOptions; i++) {
+        _provideLiquidity(_marketId, _msgSenderAddress, _predictionToken, _predictionAmount, i);
+        _initialLiquidity = _initialLiquidity.sub(_predictionAmount);
+      }
+      _provideLiquidity(_marketId, _msgSenderAddress, _predictionToken, _initialLiquidity, _totalOptions);
+    }
+
+    /**
+    * @dev Add liquidity on given option (Simplified version of _placePrediction, removed checks)
+    * @param _marketId Index of the market
+    * @param _asset The asset used by user during prediction whether it is prediction token address or in Bonus token.
+    * @param _predictionStake The amount staked by user at the time of prediction.
+    * @param _prediction The option on which user placed prediction.
+    * _predictionStake should be passed with 8 decimals, reduced it to 8 decimals to reduce the storage space of prediction data
+    */
+    function _provideLiquidity(uint _marketId, address _msgSenderAddress, address _asset, uint64 _predictionStake, uint256 _prediction) internal {
+      uint64 _predictionStakePostDeduction = _predictionStake;
+      uint decimalMultiplier = 10**predictionDecimalMultiplier;
+      UserData storage _userData = userData[_msgSenderAddress];
+      
+      uint256 unusedBalance = _userData.unusedBalance;
+      unusedBalance = unusedBalance.div(decimalMultiplier);
+      if(_predictionStake > unusedBalance)
+      {
+        _withdrawReward(defaultMaxRecords, _msgSenderAddress);
+        unusedBalance = _userData.unusedBalance;
+        unusedBalance = unusedBalance.div(decimalMultiplier);
+      }
+      require(_predictionStake <= unusedBalance); // Redundant check, can be removed
+      _userData.unusedBalance = (unusedBalance.sub(_predictionStake)).mul(decimalMultiplier);
+      _predictionStakePostDeduction = _deductFee(_marketId, _predictionStake, _msgSenderAddress);
+      
+      uint64 predictionPoints = IMarket(marketDataExtended[_marketId].marketCreatorContract).calculatePredictionPointsAndMultiplier(_msgSenderAddress, _marketId, _prediction, _predictionStakePostDeduction);
+      require(predictionPoints > 0);
+
+      _storePredictionData(_marketId, _prediction, _msgSenderAddress, _predictionStakePostDeduction, predictionPoints);
+      emit PlacePrediction(_msgSenderAddress, _predictionStake, predictionPoints, _asset, _prediction, _marketId);
+    }
+}

--- a/contracts/CyclicMarkets_2.sol
+++ b/contracts/CyclicMarkets_2.sol
@@ -1,0 +1,179 @@
+/* Copyright (C) 2021 PlotX.io
+
+  This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/ */
+
+pragma solidity 0.5.7;
+
+import "./CyclicMarkets.sol";
+import "./interfaces/IOptionPricing.sol";
+
+contract CyclicMarkets_2 is CyclicMarkets {
+
+    mapping(uint => address) public optionPricingContracts;
+    mapping(uint => uint) public marketTypeOptionPricing;
+    mapping(uint => uint) public marketOptionPricing;
+
+    /**
+    * @dev Set the option pricing contract for the market types which are already defined
+    * Should be allowed to call only once by authorized address
+    * @param _optionLengths Option lengths array
+    * @param _optionPricingContracts Address of the contracts that holds the formulae of option pricing, respectively to the `_optionLengths` array 
+    */
+    function setOptionPricingContract(uint[] memory _optionLengths, address[] memory _optionPricingContracts) public onlyAuthorized {
+      require(_optionPricingContracts.length == _optionLengths.length);
+      for(uint i = 0;i<_optionLengths.length; i++) {
+        require(_optionPricingContracts[i] != address(0));
+        optionPricingContracts[_optionLengths[i]] = _optionPricingContracts[i];
+      }
+    }
+
+    function addMarketType(uint32 _predictionTime, uint32 _optionRangePerc, uint32 _marketStartTime, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
+      revert("Deprecated");
+    }
+
+    /**
+    * @dev Add market type.
+    * @param _optionLength Option length to be used for this markettype
+    * @param _predictionTime The time duration of market.
+    * @param _optionRangePerc Option range percent of neutral min, max options (raised by 2 decimals)
+    * @param _marketStartTime Start time of first market to be created in this type
+    * @param _marketCooldownTime Cool down time of the market after market is settled
+    * @param _minTimePassed Minimum amount of time to be passed for the time factor to be kicked in while calculating option price
+    * @param _initialLiquidity Initial liquidity to be provided by the market creator for the market.
+    */
+    function newMarketType(uint _optionLength, uint32 _predictionTime, uint32 _optionRangePerc, uint32 _marketStartTime, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
+      require(marketTypeArray[marketType[_predictionTime]].predictionTime != _predictionTime);
+      require(_predictionTime > 0);
+      require(_optionRangePerc > 0);
+      require(_marketCooldownTime > 0);
+      require(_minTimePassed > 0);
+      require(optionPricingContracts[_optionLength] != address(0));
+      uint32 index = _addMarketType(_predictionTime, _optionRangePerc, _marketCooldownTime, _minTimePassed, _initialLiquidity);
+      marketTypeOptionPricing[index] = _optionLength;
+      for(uint32 i = 0;i < marketCurrencies.length; i++) {
+          marketCreationData[index][i].initialStartTime = _marketStartTime;
+      }
+    }
+
+    function updateMarketType(uint32 _marketType, uint32 _optionRangePerc, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
+      revert("Deperecated");
+    }
+
+    /**
+    * @dev Update market type.
+    * @param _marketType Index of the updating market type.
+    * @param _optionLength Option length to be used for this markettype
+    * @param _optionRangePerc Option range percent of neutral min, max options (raised by 2 decimals)
+    * @param _marketCooldownTime Cool down time of the market after market is settled
+    * @param _minTimePassed Minimum amount of time to be passed for the time factor to be kicked in while calculating option price
+    * @param _initialLiquidity Initial liquidity to be provided by the market creator for the market.
+    */
+    function alterMarketType(uint32 _marketType, uint _optionLength, uint32 _optionRangePerc, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
+      require(_optionRangePerc > 0);
+      require(_marketCooldownTime > 0);
+      require(_minTimePassed > 0);
+      require(optionPricingContracts[_optionLength] != address(0));
+      MarketTypeData storage _marketTypeArray = marketTypeArray[_marketType];
+      marketTypeOptionPricing[_marketType] = _optionLength;
+      require(_marketTypeArray.predictionTime != 0);
+      _marketTypeArray.optionRangePerc = _optionRangePerc;
+      _marketTypeArray.cooldownTime = _marketCooldownTime;
+      _marketTypeArray.minTimePassed = _minTimePassed;
+      _marketTypeArray.initialLiquidity = _initialLiquidity;
+      emit MarketTypes(_marketType, _marketTypeArray.predictionTime, _marketCooldownTime, _optionRangePerc, true, _minTimePassed, _initialLiquidity);
+    }
+
+    /**
+    * @dev Create the market.
+    * @param _marketCurrencyIndex The index of market currency feed
+    * @param _marketTypeIndex The time duration of market.
+    * @param _roundId Round Id to settle previous market (If applicable, else pass 0)
+    */
+    function createMarket(uint32 _marketCurrencyIndex,uint32 _marketTypeIndex, uint80 _roundId) public {
+      address _msgSenderAddress = _msgSender();
+      require(isAuthorizedCreator[_msgSenderAddress], "Not authorized");
+      MarketTypeData storage _marketType = marketTypeArray[_marketTypeIndex];
+      MarketCurrency storage _marketCurrency = marketCurrencies[_marketCurrencyIndex];
+      MarketCreationData storage _marketCreationData = marketCreationData[_marketTypeIndex][_marketCurrencyIndex];
+      require(!_marketType.paused && !_marketCreationData.paused);
+      _closePreviousMarketWithRoundId( _marketTypeIndex, _marketCurrencyIndex, _roundId);
+      uint32 _startTime = calculateStartTimeForMarket(_marketCurrencyIndex, _marketTypeIndex);
+      uint32[] memory _marketTimes = new uint32[](4);
+      uint64[] memory _optionRanges = new uint64[](2);
+      uint64 _marketIndex = allMarkets.getTotalMarketsLength();
+      marketOptionPricing[_marketIndex] = marketTypeOptionPricing[_marketTypeIndex];
+      _optionRanges = _calculateOptionRanges(marketOptionPricing[_marketIndex], _marketType.optionRangePerc, _marketCurrency.decimals, _marketCurrency.roundOfToNearest, _marketCurrency.marketFeed);
+      _marketTimes[0] = _startTime; 
+      _marketTimes[1] = _marketType.predictionTime;
+      _marketTimes[2] = _marketType.predictionTime*2;
+      _marketTimes[3] = _marketType.cooldownTime;
+      marketPricingData[_marketIndex] = PricingData(stakingFactorMinStake, stakingFactorWeightage, currentPriceWeightage, _marketType.minTimePassed);
+      marketData[_marketIndex] = MarketData(_marketTypeIndex, _marketCurrencyIndex, _msgSenderAddress);
+      allMarkets.createMarket(_marketTimes, _optionRanges, _msgSenderAddress, _marketType.initialLiquidity);
+      
+      (_marketCreationData.penultimateMarket, _marketCreationData.latestMarket) =
+       (_marketCreationData.latestMarket, _marketIndex);
+      
+      emit MarketParams(_marketIndex, _msgSenderAddress, _marketTypeIndex, _marketCurrency.currencyName, stakingFactorMinStake,stakingFactorWeightage,currentPriceWeightage,_marketType.minTimePassed);      
+    }
+
+    /**
+     * @dev Internal function to calculate option ranges for the market
+     * @param _optionRangePerc Defined Option percent
+     * @param _decimals Decimals of the given feed address
+     * @param _roundOfToNearest Round of the option range to the nearest multiple
+     * @param _marketFeed Market Feed address
+     */
+    function _calculateOptionRanges(uint _optionLength, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest, address _marketFeed) internal view returns(uint64[] memory _optionRanges) {
+      uint currentPrice = IOracle(_marketFeed).getLatestPrice();
+      _optionRanges = IOptionPricing(optionPricingContracts[_optionLength]).calculateOptionRanges(currentPrice, _optionRangePerc, _decimals, _roundOfToNearest);
+    }
+
+    /**
+     * @dev Gets price for given market and option
+     * @param _marketId  Market ID
+     * @param _prediction  prediction option
+     * @return  option price
+     **/
+    function getOptionPrice(uint _marketId, uint256 _prediction) public view returns(uint64) {
+      uint _marketCurr = marketData[_marketId].marketCurrencyIndex;
+
+      uint[] memory _marketPricingDataArray = new uint[](4);
+      PricingData storage _marketPricingData = marketPricingData[_marketId];
+      _marketPricingDataArray[0] = _marketPricingData.stakingFactorMinStake;
+      _marketPricingDataArray[1] = _marketPricingData.stakingFactorWeightage;
+      _marketPricingDataArray[2] = _marketPricingData.currentPriceWeightage;
+      _marketPricingDataArray[3] = _marketPricingData.minTimePassed;
+
+      // Fetching current price
+      uint currentPrice = IOracle(marketCurrencies[_marketCurr].marketFeed).getLatestPrice();
+
+      return IOptionPricing(optionPricingContracts[marketOptionPricing[_marketId]]).getOptionPrice(_marketId, currentPrice, _prediction, _marketPricingDataArray, address(allMarkets));
+
+    }
+
+    /**
+     * @dev Gets price for all the options in a market
+     * @param _marketId  Market ID
+     * @return _optionPrices array consisting of prices for all available options
+     **/
+    function getAllOptionPrices(uint _marketId) external view returns(uint64[] memory _optionPrices) {
+      _optionPrices = new uint64[](marketOptionPricing[_marketId]);
+      for(uint i=0; i< marketOptionPricing[_marketId]; i++) {
+        _optionPrices[i] = getOptionPrice(_marketId,i+1);
+      }
+
+    }
+
+}

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -44,16 +44,13 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
 
     /**
     * @dev Set the pre buffer time for creating market of given type
-    * @param _marketTypes Market type array
+    * @param _marketType Market type
     * @param _preBufferTime Pre buffer time to allow market creation when a market is already live
     */
-    function setMarketCreationPreBuffer(uint[] memory _marketTypes, uint[] memory _preBufferTime) public onlyAuthorized {
-      require(_marketTypes.length == _preBufferTime.length);
-      for(uint i = 0;i<_marketTypes.length; i++) {
-        require(_marketTypes[i] < marketTypeArray.length);
-        require(_preBufferTime[i] < marketTypeArray[_marketTypes[i]].predictionTime);
-        marketCreationPreBuffer[_marketTypes[i]] = _preBufferTime[i];
-      }
+    function setMarketCreationPreBuffer(uint _marketType, uint _preBufferTime) public onlyAuthorized {
+      require(_marketType < marketTypeArray.length);
+      require(_preBufferTime < marketTypeArray[_marketType].predictionTime);
+      marketCreationPreBuffer[_marketType] = _preBufferTime;
     }
 
     function addMarketType(uint32 _predictionTime, uint32 _optionRangePerc, uint32 _marketStartTime, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
@@ -166,7 +163,7 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
       _startTime = calculateStartTimeForMarket(_marketCurrencyIndex, _marketTypeIndex);
       if(uint(allMarkets.marketStatus(latestMarket)) == uint(PredictionStatus.Live)) {
         _startTime = _startTime.add(_predictionTime);
-        require(_startTime >= marketCreationPreBuffer[_marketTypeIndex].add(now));
+        require(_startTime <= marketCreationPreBuffer[_marketTypeIndex].add(now));
       }
     }
 

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -53,8 +53,8 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
       marketCreationPreBuffer[_marketType] = _preBufferTime;
     }
 
-    function addMarketType(uint32 _predictionTime, uint32 _optionRangePerc, uint32 _marketStartTime, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
-      revert("Deprecated");
+    function addMarketType(uint32 _predictionTime, uint32 _optionRangePerc, uint32 _marketStartTime, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external {
+      revert("DEPR");
     }
 
     /**
@@ -83,8 +83,8 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
       }
     }
 
-    function updateMarketType(uint32 _marketType, uint32 _optionRangePerc, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external onlyAuthorized {
-      revert("Deperecated");
+    function updateMarketType(uint32 _marketType, uint32 _optionRangePerc, uint32 _marketCooldownTime, uint32 _minTimePassed, uint64 _initialLiquidity) external {
+      revert("DEPR");
     }
 
     /**
@@ -191,11 +191,11 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
       (predictionPoints, isMultiplierApplied) = CyclicMarkets.calculatePredictionPoints(_marketId, _prediction, _user, _multiplierApplied, _predictionStake);
     	uint _marketType = marketData[_marketId].marketTypeIndex;
       EarlyParticipantMultiplier memory _multiplierData = earlyParticipantMultiplier[_marketType];
-      uint _startTime = calculateStartTimeForMarket(uint32(marketData[_marketId].marketCurrencyIndex), uint32(_marketType));
-      uint _timePassed = uint(now).sub(_startTime);
-      // If market is identified as upcoming, then the time passed should be reset 
-      if(_marketId == marketCreationData[_marketType][marketData[_marketId].marketCurrencyIndex].penultimateMarket) {
-        _timePassed = 0;
+      (, uint _startTime) = allMarkets.getMarketOptionPricingParams(_marketId, _prediction);
+      uint _timePassed;
+      // If given market is buffer market, then the time passed should be zero, as start time will not be reached 
+      if(_startTime < now) {
+        _timePassed = uint(now).sub(_startTime);
       }
       if(_timePassed <= _multiplierData.cutoffTime) {
         uint64 _muliplier = 100;

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -18,7 +18,7 @@ pragma solidity 0.5.7;
 import "./CyclicMarkets.sol";
 import "./interfaces/IOptionPricing.sol";
 
-contract CyclicMarkets_2 is CyclicMarkets {
+contract CyclicMarkets_3 is CyclicMarkets {
 
     mapping(uint => address) public optionPricingContracts;
     mapping(uint => uint) public marketTypeOptionPricing;

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -121,7 +121,7 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
     */
     function createMarket(uint32 _marketCurrencyIndex,uint32 _marketTypeIndex, uint80 _roundId) public {
       address _msgSenderAddress = _msgSender();
-      require(isAuthorizedCreator[_msgSenderAddress], "Not authorized");
+      require(isAuthorizedCreator[_msgSenderAddress]);
       MarketTypeData storage _marketType = marketTypeArray[_marketTypeIndex];
       MarketCurrency storage _marketCurrency = marketCurrencies[_marketCurrencyIndex];
       MarketCreationData storage _marketCreationData = marketCreationData[_marketTypeIndex][_marketCurrencyIndex];

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -35,6 +35,7 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
       require(_optionPricingContracts.length == _optionLengths.length);
       for(uint i = 0;i<_optionLengths.length; i++) {
         require(_optionPricingContracts[i] != address(0) && _optionLengths[i] > 1);
+        require(IOptionPricing(_optionPricingContracts[i]).optionLength() == _optionLengths[i]);
         optionPricingContracts[_optionLengths[i]] = _optionPricingContracts[i];
       }
     }

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -115,7 +115,7 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
       _closePreviousMarketWithRoundId( _marketTypeIndex, _marketCurrencyIndex, _roundId);
       uint32 _startTime = calculateStartTimeForMarket(_marketCurrencyIndex, _marketTypeIndex);
       uint32[] memory _marketTimes = new uint32[](4);
-      uint64[] memory _optionRanges = new uint64[](2);
+      uint64[] memory _optionRanges = new uint64[](marketTypeOptionPricing[_marketTypeIndex]);
       uint64 _marketIndex = allMarkets.getTotalMarketsLength();
       marketOptionPricing[_marketIndex] = marketTypeOptionPricing[_marketTypeIndex];
       _optionRanges = _calculateOptionRanges(marketOptionPricing[_marketIndex], _marketType.optionRangePerc, _marketCurrency.decimals, _marketCurrency.roundOfToNearest, _marketCurrency.marketFeed);
@@ -152,6 +152,11 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
      * @return  option price
      **/
     function getOptionPrice(uint _marketId, uint256 _prediction) public view returns(uint64) {
+      //For the markets which are created before the upgrade
+      if(marketOptionPricing[_marketId] == 0) {
+        return super.getOptionPrice(_marketId, _prediction);
+      }
+
       uint _marketCurr = marketData[_marketId].marketCurrencyIndex;
 
       uint[] memory _marketPricingDataArray = new uint[](4);
@@ -174,8 +179,12 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
      * @return _optionPrices array consisting of prices for all available options
      **/
     function getAllOptionPrices(uint _marketId) external view returns(uint64[] memory _optionPrices) {
-      _optionPrices = new uint64[](marketOptionPricing[_marketId]);
-      for(uint i=0; i< marketOptionPricing[_marketId]; i++) {
+      uint _optionLength = marketOptionPricing[_marketId];
+      if(_optionLength == 0) {
+        _optionLength = 3;
+      }
+      _optionPrices = new uint64[](_optionLength);
+      for(uint i=0; i< _optionLength; i++) {
         _optionPrices[i] = getOptionPrice(_marketId,i+1);
       }
 

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -135,6 +135,20 @@ contract CyclicMarkets_3 is CyclicMarkets_2 {
     }
 
     /**
+    * @dev Internal function to if the previous market is live or not
+    * @param _marketTypeIndex Index of the market type
+    * @param _marketCurrencyIndex Index of the market currency
+    * @param _roundId RoundId of the feed for the settlement price
+    */
+    function _closePreviousMarketWithRoundId(uint64 _marketTypeIndex, uint64 _marketCurrencyIndex, uint80 _roundId) internal {
+      MarketCreationData storage _marketCreationData = marketCreationData[_marketTypeIndex][_marketCurrencyIndex];
+      uint64 currentMarket = _marketCreationData.latestMarket;
+      if(currentMarket != 0) {
+        require(uint(allMarkets.marketStatus(currentMarket)) >= uint(PredictionStatus.InSettlement));
+      }
+    }
+
+    /**
      * @dev Internal function to calculate option ranges for the market
      * @param _optionRangePerc Defined Option percent
      * @param _decimals Decimals of the given feed address

--- a/contracts/CyclicMarkets_3.sol
+++ b/contracts/CyclicMarkets_3.sol
@@ -15,10 +15,10 @@
 
 pragma solidity 0.5.7;
 
-import "./CyclicMarkets.sol";
+import "./CyclicMarkets_2.sol";
 import "./interfaces/IOptionPricing.sol";
 
-contract CyclicMarkets_3 is CyclicMarkets {
+contract CyclicMarkets_3 is CyclicMarkets_2 {
 
     mapping(uint => address) public optionPricingContracts;
     mapping(uint => uint) public marketTypeOptionPricing;

--- a/contracts/OptionPricing2.sol
+++ b/contracts/OptionPricing2.sol
@@ -1,0 +1,108 @@
+pragma solidity 0.5.7;
+
+import "./external/openzeppelin-solidity/math/SafeMath.sol";
+import "./interfaces/IOptionPricing.sol";
+import "./interfaces/IAllMarkets.sol";
+
+contract OptionPricing2 is IOptionPricing {
+    using SafeMath32 for uint32;
+    using SafeMath64 for uint64;
+    using SafeMath128 for uint128;
+    using SafeMath for uint;
+
+    uint public constant OptionLength = 2;
+
+    function calculateOptionRanges(uint currentPrice, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest) public pure returns(uint64[] memory _optionRanges) {
+        _optionRanges = new uint64[](1);
+        _optionRanges[0] =  uint64((ceil(currentPrice.div(_roundOfToNearest), 10**_decimals)).mul(_roundOfToNearest)); 
+    }
+
+    /**
+     * @dev Gets price for given market and option
+     * @param _prediction  prediction option
+     * @return  option price
+     **/
+    function getOptionPrice(uint _marketId, uint _currentPrice, uint _prediction, uint[] memory _marketPricingData, address _allMarketsAddress) public view returns(uint64) {
+      IAllMarkets allMarkets = IAllMarkets(_allMarketsAddress); 
+      (uint64[] memory _optionRanges,, uint _predictionTime,,) = allMarkets.getMarketData(_marketId);
+      (uint[] memory _optionPricingParams, uint32 _startTime) = allMarkets.getMarketOptionPricingParams(_marketId,_prediction);
+      uint stakingFactorConst;
+      uint optionPrice; 
+      uint256 totalStaked = _optionPricingParams[1];
+      // Checking if current stake in market reached minimum stake required for considering staking factor.
+      if(totalStaked > _marketPricingData[0])
+      {
+        // 10000 / staking weightage
+        stakingFactorConst = uint(10000).div(_marketPricingData[1]); 
+        // (stakingFactorConst x Amount staked in option x 10^18) / Total staked in market --- (1)
+        optionPrice = (stakingFactorConst.mul(_optionPricingParams[0]).mul(10**18).div(totalStaked)); 
+      }
+      uint timeElapsed = uint(now).sub(_startTime);
+      // max(timeElapsed, minTimePassed)
+      if(timeElapsed < _marketPricingData[3]) {
+        timeElapsed = _marketPricingData[3];
+      }
+      uint[] memory _distanceData = getOptionDistanceData(_currentPrice,_prediction, _optionRanges);
+
+      // (Time Elapsed x 10000) / ((Max Distance + 1) x currentPriceWeightage)
+      uint timeFactor = timeElapsed.mul(10000).div((_distanceData[0].add(1)).mul(_marketPricingData[2]));
+
+      uint totalTime = _predictionTime;
+      // (1) + ((Option Distance from max distance + 1) x timeFactor x 10^18 / Total Prediction Time)  -- (2)
+      optionPrice = optionPrice.add((_distanceData[1].add(1)).mul(timeFactor).mul(10**18).div(totalTime));  
+      // (2) / ((stakingFactorConst x 10^13) + timeFactor x 10^13 x (cummulative option distaance + 2) / Total Prediction Time)
+      optionPrice = optionPrice.div(stakingFactorConst.mul(10**13).add(timeFactor.mul(10**13).mul(_distanceData[2].add(2)).div(totalTime)));
+
+      // option price for `_prediction` in 10^5 format
+      return uint64(optionPrice);
+
+    }
+
+    /**
+     * @dev Gets price for given market and option
+     * @param _prediction  prediction option
+     * @return  Array consist of Max Distance between current option and any option, predicting Option distance from max distance, cummulative option distance
+     **/
+    function getOptionDistanceData(uint _currentPrice, uint _prediction,uint64[] memory _optionRanges) internal pure returns(uint[] memory) {
+      // [0]--> Max Distance between current option and any option, (For 3 options, if current option is 2 it will be `1`. else, it will be `2`) 
+      // [1]--> Predicting option distance from Max distance, (MaxDistance - | currentOption - predicting option |)
+      // [2]--> sum of all possible option distances,  
+      uint[] memory _distanceData = new uint256[](3); 
+
+      _distanceData[0] = 1;
+      // current option based on current price
+      uint currentOption;
+      _distanceData[2] = 2;
+      if(_currentPrice < _optionRanges[0])
+      {
+        currentOption = 1;
+      } else {
+        currentOption = 2;
+        _distanceData[0] = 1;
+        _distanceData[2] = 1;
+      }
+
+      // MaxDistance - | currentOption - predicting option |
+      _distanceData[1] = _distanceData[0].sub(modDiff(currentOption,_prediction)); 
+      return _distanceData;
+    }
+
+    /**
+     * @dev  Calculates difference between `a` and `b`.
+     **/
+    function modDiff(uint a, uint b) internal pure returns(uint) {
+      if(a>b)
+      {
+        return a.sub(b);
+      } else {
+        return b.sub(a);
+      }
+    }
+
+    /**
+    * @dev Internal function to perfrom ceil operation of given params
+    */
+    function ceil(uint256 a, uint256 m) internal pure returns (uint256) {
+        return ((a + m - 1) / m) * m;
+    }
+}

--- a/contracts/OptionPricing2.sol
+++ b/contracts/OptionPricing2.sol
@@ -10,11 +10,17 @@ contract OptionPricing2 is IOptionPricing {
     using SafeMath128 for uint128;
     using SafeMath for uint;
 
-    uint public constant OptionLength = 2;
+    uint internal constant _optionLength = 2;
+
+    function optionLength() public view returns(uint) {
+      return _optionLength;
+    }
 
     function calculateOptionRanges(uint currentPrice, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest) public pure returns(uint64[] memory _optionRanges) {
-        _optionRanges = new uint64[](1);
-        _optionRanges[0] =  uint64((ceil(currentPrice.div(_roundOfToNearest), 10**_decimals)).mul(_roundOfToNearest)); 
+        _optionRanges = new uint64[](_optionLength - 1);
+        uint _option = (ceil(currentPrice.div(_roundOfToNearest), 10**_decimals)).mul(_roundOfToNearest);
+        require(_option == uint64(_option), "Uint 64 Overflow");
+        _optionRanges[0] = uint64(_option);
     }
 
     /**
@@ -34,7 +40,9 @@ contract OptionPricing2 is IOptionPricing {
         return uint64(uint(100000).div(optionLen));
 
       } else {
-        return uint64(uint(100000).mul(_optionPricingParams[0]).div(_optionPricingParams[1]));
+        uint _value = uint(100000).mul(_optionPricingParams[0]).div(_optionPricingParams[1]);
+        require(_value == uint64(_value), "Uint 64 Overflow");
+        return uint64(_value);
       }
 
 

--- a/contracts/OptionPricing2.sol
+++ b/contracts/OptionPricing2.sol
@@ -30,14 +30,13 @@ contract OptionPricing2 is IOptionPricing {
      **/
     function getOptionPrice(uint _marketId, uint _currentPrice, uint _prediction, uint[] memory _marketPricingData, address _allMarketsAddress) public view returns(uint64) {
       IAllMarkets allMarkets = IAllMarkets(_allMarketsAddress); 
-            uint optionLen = allMarkets.getTotalOptions(_marketId);
       (uint[] memory _optionPricingParams,) = allMarkets.getMarketOptionPricingParams(_marketId,_prediction);
 
       // Checking if current stake in market reached minimum stake required for considering staking factor.
       if(_optionPricingParams[1] < _marketPricingData[0] || _optionPricingParams[0] == 0)
       {
 
-        return uint64(uint(100000).div(optionLen));
+        return uint64(uint(100000).div(_optionLength));
 
       } else {
         uint _value = uint(100000).mul(_optionPricingParams[0]).div(_optionPricingParams[1]);

--- a/contracts/OptionPricing2.sol
+++ b/contracts/OptionPricing2.sol
@@ -24,79 +24,20 @@ contract OptionPricing2 is IOptionPricing {
      **/
     function getOptionPrice(uint _marketId, uint _currentPrice, uint _prediction, uint[] memory _marketPricingData, address _allMarketsAddress) public view returns(uint64) {
       IAllMarkets allMarkets = IAllMarkets(_allMarketsAddress); 
-      (uint64[] memory _optionRanges,, uint _predictionTime,,) = allMarkets.getMarketData(_marketId);
-      (uint[] memory _optionPricingParams, uint32 _startTime) = allMarkets.getMarketOptionPricingParams(_marketId,_prediction);
-      uint stakingFactorConst;
-      uint optionPrice; 
-      uint256 totalStaked = _optionPricingParams[1];
+            uint optionLen = allMarkets.getTotalOptions(_marketId);
+      (uint[] memory _optionPricingParams,) = allMarkets.getMarketOptionPricingParams(_marketId,_prediction);
+
       // Checking if current stake in market reached minimum stake required for considering staking factor.
-      if(totalStaked > _marketPricingData[0])
+      if(_optionPricingParams[1] < _marketPricingData[0] || _optionPricingParams[0] == 0)
       {
-        // 10000 / staking weightage
-        stakingFactorConst = uint(10000).div(_marketPricingData[1]); 
-        // (stakingFactorConst x Amount staked in option x 10^18) / Total staked in market --- (1)
-        optionPrice = (stakingFactorConst.mul(_optionPricingParams[0]).mul(10**18).div(totalStaked)); 
-      }
-      uint timeElapsed = uint(now).sub(_startTime);
-      // max(timeElapsed, minTimePassed)
-      if(timeElapsed < _marketPricingData[3]) {
-        timeElapsed = _marketPricingData[3];
-      }
-      uint[] memory _distanceData = getOptionDistanceData(_currentPrice,_prediction, _optionRanges);
 
-      // (Time Elapsed x 10000) / ((Max Distance + 1) x currentPriceWeightage)
-      uint timeFactor = timeElapsed.mul(10000).div((_distanceData[0].add(1)).mul(_marketPricingData[2]));
+        return uint64(uint(100000).div(optionLen));
 
-      uint totalTime = _predictionTime;
-      // (1) + ((Option Distance from max distance + 1) x timeFactor x 10^18 / Total Prediction Time)  -- (2)
-      optionPrice = optionPrice.add((_distanceData[1].add(1)).mul(timeFactor).mul(10**18).div(totalTime));  
-      // (2) / ((stakingFactorConst x 10^13) + timeFactor x 10^13 x (cummulative option distaance + 2) / Total Prediction Time)
-      optionPrice = optionPrice.div(stakingFactorConst.mul(10**13).add(timeFactor.mul(10**13).mul(_distanceData[2].add(2)).div(totalTime)));
-
-      // option price for `_prediction` in 10^5 format
-      return uint64(optionPrice);
-
-    }
-
-    /**
-     * @dev Gets price for given market and option
-     * @param _prediction  prediction option
-     * @return  Array consist of Max Distance between current option and any option, predicting Option distance from max distance, cummulative option distance
-     **/
-    function getOptionDistanceData(uint _currentPrice, uint _prediction,uint64[] memory _optionRanges) internal pure returns(uint[] memory) {
-      // [0]--> Max Distance between current option and any option, (For 3 options, if current option is 2 it will be `1`. else, it will be `2`) 
-      // [1]--> Predicting option distance from Max distance, (MaxDistance - | currentOption - predicting option |)
-      // [2]--> sum of all possible option distances,  
-      uint[] memory _distanceData = new uint256[](3); 
-
-      _distanceData[0] = 1;
-      // current option based on current price
-      uint currentOption;
-      _distanceData[2] = 2;
-      if(_currentPrice < _optionRanges[0])
-      {
-        currentOption = 1;
       } else {
-        currentOption = 2;
-        _distanceData[0] = 1;
-        _distanceData[2] = 1;
+        return uint64(uint(100000).mul(_optionPricingParams[0]).div(_optionPricingParams[1]));
       }
 
-      // MaxDistance - | currentOption - predicting option |
-      _distanceData[1] = _distanceData[0].sub(modDiff(currentOption,_prediction)); 
-      return _distanceData;
-    }
 
-    /**
-     * @dev  Calculates difference between `a` and `b`.
-     **/
-    function modDiff(uint a, uint b) internal pure returns(uint) {
-      if(a>b)
-      {
-        return a.sub(b);
-      } else {
-        return b.sub(a);
-      }
     }
 
     /**

--- a/contracts/OptionPricing3.sol
+++ b/contracts/OptionPricing3.sol
@@ -44,7 +44,7 @@ contract OptionPricing3 is IOptionPricing {
         optionPrice = (stakingFactorConst.mul(_optionPricingParams[0]).mul(10**18).div(totalStaked)); 
       }
       uint timeElapsed;
-      if(_startTime > now) {
+      if(now > _startTime) {
         timeElapsed= uint(now).sub(_startTime);
       }
       // max(timeElapsed, minTimePassed)

--- a/contracts/OptionPricing3.sol
+++ b/contracts/OptionPricing3.sol
@@ -10,7 +10,11 @@ contract OptionPricing3 is IOptionPricing {
     using SafeMath128 for uint128;
     using SafeMath for uint;
 
-    uint public constant OptionLength = 3;
+    uint internal constant _optionLength = 3;
+
+    function optionLength() public view returns(uint) {
+      return _optionLength;
+    }
 
     function calculateOptionRanges(uint currentPrice, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest) public pure returns(uint64[] memory _optionRanges) {
         uint optionRangePerc = currentPrice.mul(_optionRangePerc.div(2)).div(10000);

--- a/contracts/OptionPricing3.sol
+++ b/contracts/OptionPricing3.sol
@@ -43,7 +43,10 @@ contract OptionPricing3 is IOptionPricing {
         // (stakingFactorConst x Amount staked in option x 10^18) / Total staked in market --- (1)
         optionPrice = (stakingFactorConst.mul(_optionPricingParams[0]).mul(10**18).div(totalStaked)); 
       }
-      uint timeElapsed = uint(now).sub(_startTime);
+      uint timeElapsed;
+      if(_startTime > now) {
+        timeElapsed= uint(now).sub(_startTime);
+      }
       // max(timeElapsed, minTimePassed)
       if(timeElapsed < _marketPricingData[3]) {
         timeElapsed = _marketPricingData[3];

--- a/contracts/OptionPricing3.sol
+++ b/contracts/OptionPricing3.sol
@@ -1,0 +1,112 @@
+pragma solidity 0.5.7;
+
+import "./external/openzeppelin-solidity/math/SafeMath.sol";
+import "./interfaces/IOptionPricing.sol";
+import "./interfaces/IAllMarkets.sol";
+
+contract OptionPricing3 is IOptionPricing {
+    using SafeMath32 for uint32;
+    using SafeMath64 for uint64;
+    using SafeMath128 for uint128;
+    using SafeMath for uint;
+
+    uint public constant OptionLength = 3;
+
+    function calculateOptionRanges(uint currentPrice, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest) public pure returns(uint64[] memory _optionRanges) {
+        uint optionRangePerc = currentPrice.mul(_optionRangePerc.div(2)).div(10000);
+        _optionRanges = new uint64[](2);
+        _optionRanges[0] = uint64((ceil(currentPrice.sub(optionRangePerc).div(_roundOfToNearest), 10**_decimals)).mul(_roundOfToNearest));
+        _optionRanges[1] = uint64((ceil(currentPrice.add(optionRangePerc).div(_roundOfToNearest), 10**_decimals)).mul(_roundOfToNearest));
+    }
+
+    /**
+     * @dev Gets price for given market and option
+     * @param _prediction  prediction option
+     * @return  option price
+     **/
+    function getOptionPrice(uint _marketId, uint _currentPrice, uint _prediction, uint[] memory _marketPricingData, address _allMarketsAddress) public view returns(uint64) {
+      IAllMarkets allMarkets = IAllMarkets(_allMarketsAddress); 
+      (uint64[] memory _optionRanges,, uint _predictionTime,,) = allMarkets.getMarketData(_marketId);
+      (uint[] memory _optionPricingParams, uint32 _startTime) = allMarkets.getMarketOptionPricingParams(_marketId,_prediction);
+      uint stakingFactorConst;
+      uint optionPrice; 
+      uint256 totalStaked = _optionPricingParams[1];
+      // Checking if current stake in market reached minimum stake required for considering staking factor.
+      if(totalStaked > _marketPricingData[0])
+      {
+        // 10000 / staking weightage
+        stakingFactorConst = uint(10000).div(_marketPricingData[1]); 
+        // (stakingFactorConst x Amount staked in option x 10^18) / Total staked in market --- (1)
+        optionPrice = (stakingFactorConst.mul(_optionPricingParams[0]).mul(10**18).div(totalStaked)); 
+      }
+      uint timeElapsed = uint(now).sub(_startTime);
+      // max(timeElapsed, minTimePassed)
+      if(timeElapsed < _marketPricingData[3]) {
+        timeElapsed = _marketPricingData[3];
+      }
+      uint[] memory _distanceData = getOptionDistanceData(_currentPrice,_prediction, _optionRanges);
+
+      // (Time Elapsed x 10000) / ((Max Distance + 1) x currentPriceWeightage)
+      uint timeFactor = timeElapsed.mul(10000).div((_distanceData[0].add(1)).mul(_marketPricingData[2]));
+
+      uint totalTime = _predictionTime;
+      // (1) + ((Option Distance from max distance + 1) x timeFactor x 10^18 / Total Prediction Time)  -- (2)
+      optionPrice = optionPrice.add((_distanceData[1].add(1)).mul(timeFactor).mul(10**18).div(totalTime));  
+      // (2) / ((stakingFactorConst x 10^13) + timeFactor x 10^13 x (cummulative option distaance + 3) / Total Prediction Time)
+      optionPrice = optionPrice.div(stakingFactorConst.mul(10**13).add(timeFactor.mul(10**13).mul(_distanceData[2].add(3)).div(totalTime)));
+
+      // option price for `_prediction` in 10^5 format
+      return uint64(optionPrice);
+
+    }
+
+    /**
+     * @dev Gets price for given market and option
+     * @param _prediction  prediction option
+     * @return  Array consist of Max Distance between current option and any option, predicting Option distance from max distance, cummulative option distance
+     **/
+    function getOptionDistanceData(uint _currentPrice, uint _prediction,uint64[] memory _optionRanges) internal pure returns(uint[] memory) {
+      // [0]--> Max Distance between current option and any option, (For 3 options, if current option is 2 it will be `1`. else, it will be `2`) 
+      // [1]--> Predicting option distance from Max distance, (MaxDistance - | currentOption - predicting option |)
+      // [2]--> sum of all possible option distances,  
+      uint[] memory _distanceData = new uint256[](3); 
+
+      _distanceData[0] = 2;
+      // current option based on current price
+      uint currentOption;
+      _distanceData[2] = 3;
+      if(_currentPrice < _optionRanges[0])
+      {
+        currentOption = 1;
+      } else if(_currentPrice > _optionRanges[1]) {
+        currentOption = 3;
+      } else {
+        currentOption = 2;
+        _distanceData[0] = 1;
+        _distanceData[2] = 1;
+      }
+
+      // MaxDistance - | currentOption - predicting option |
+      _distanceData[1] = _distanceData[0].sub(modDiff(currentOption,_prediction)); 
+      return _distanceData;
+    }
+
+    /**
+     * @dev  Calculates difference between `a` and `b`.
+     **/
+    function modDiff(uint a, uint b) internal pure returns(uint) {
+      if(a>b)
+      {
+        return a.sub(b);
+      } else {
+        return b.sub(a);
+      }
+    }
+
+    /**
+    * @dev Internal function to perfrom ceil operation of given params
+    */
+    function ceil(uint256 a, uint256 m) internal pure returns (uint256) {
+        return ((a + m - 1) / m) * m;
+    }
+}

--- a/contracts/interfaces/IOptionPricing.sol
+++ b/contracts/interfaces/IOptionPricing.sol
@@ -1,0 +1,23 @@
+/* Copyright (C) 2021 PlotX.io
+
+  This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+    along with this program.  If not, see http://www.gnu.org/licenses/ */
+
+pragma solidity 0.5.7;
+
+contract IOptionPricing {
+    function calculateOptionRanges(uint currentPrice, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest) public pure returns(uint64[] memory _optionRanges);
+    
+    function getOptionPrice(uint _marketId, uint _currentPrice, uint _prediction, uint[] memory _marketPricingData, address _allMarketsAddress) public view returns(uint64);
+
+}

--- a/contracts/interfaces/IOptionPricing.sol
+++ b/contracts/interfaces/IOptionPricing.sol
@@ -16,6 +16,9 @@
 pragma solidity 0.5.7;
 
 contract IOptionPricing {
+
+    function optionLength() public view returns(uint);
+
     function calculateOptionRanges(uint currentPrice, uint _optionRangePerc, uint64 _decimals, uint8 _roundOfToNearest) public pure returns(uint64[] memory _optionRanges);
     
     function getOptionPrice(uint _marketId, uint _currentPrice, uint _prediction, uint[] memory _marketPricingData, address _allMarketsAddress) public view returns(uint64);

--- a/contracts/mock/MockCyclicMarkets_3.sol
+++ b/contracts/mock/MockCyclicMarkets_3.sol
@@ -1,0 +1,36 @@
+pragma solidity 0.5.7;
+
+import "../CyclicMarkets_3.sol";
+
+contract MockCyclicMarkets_3 is CyclicMarkets_3 {
+
+    uint64 public nextOptionPrice;
+
+    function setNextOptionPrice(uint64 _price) public {
+        nextOptionPrice = _price;
+    }
+
+    function getOptionPrice(uint _marketId, uint256 _prediction) public view returns(uint64 _optionPrice) {
+        if(nextOptionPrice !=0) {
+            return nextOptionPrice;
+        }
+        else  {
+            return super.getOptionPrice(_marketId, _prediction);
+        }
+    }
+
+     /**
+     * @dev Gets price for all the options in a market
+     * @param _marketId  Market ID
+     * @return _optionPrices array consisting of prices for all available options
+     **/
+    function getAllOptionPrices(uint _marketId) external view returns(uint64[] memory _optionPrices) {
+      uint _optionLength;
+      _optionLength = IOptionPricing(marketOptionPricing[_marketId]).optionLength();
+      _optionPrices = new uint64[](_optionLength);
+      for(uint i=0; i< _optionLength; i++) {
+        _optionPrices[i] = getOptionPrice(_marketId,i+1);
+      }
+
+    }
+}

--- a/test/MarketCreationPreBuffer.test.js
+++ b/test/MarketCreationPreBuffer.test.js
@@ -1,0 +1,414 @@
+const assertRevert = require("./utils/assertRevert.js").assertRevert;
+const { assert } = require("chai");
+const OwnedUpgradeabilityProxy = artifacts.require("OwnedUpgradeabilityProxy");
+const Master = artifacts.require("Master");
+const PlotusToken = artifacts.require("MockPLOT");
+const MockchainLinkBTC = artifacts.require("MockChainLinkAggregator");
+const AllMarkets = artifacts.require("MockAllMarkets");
+const CyclicMarkets = artifacts.require("MockCyclicMarkets");
+const CyclicMarkets_3 = artifacts.require("MockCyclicMarkets_3");
+const AllPlotMarkets_4 = artifacts.require("AllPlotMarkets_4");
+const OptionPricing2 = artifacts.require("OptionPricing2");
+const OptionPricing3 = artifacts.require("OptionPricing3");
+const increaseTime = require("./utils/increaseTime.js").increaseTime;
+const increaseTimeTo = require("./utils/increaseTime.js").increaseTimeTo;
+const { encode3 } = require("./utils/encoder.js");
+const signAndExecuteMetaTx = require("./utils/signAndExecuteMetaTx.js").signAndExecuteMetaTx;
+const { toHex, toWei, toChecksumAddress } = require("./utils/ethTools");
+let privateKeyList = ["fb437e3e01939d9d4fef43138249f23dc1d0852e69b0b5d1647c087f869fabbd", "7c85a1f1da3120c941b83d71a154199ee763307683f206b98ad92c3b4e0af13e", "ecc9b35bf13bd5459350da564646d05c5664a7476fe5acdf1305440f88ed784c", "f4470c3fca4dbef1b2488d016fae25978effc586a1f83cb29ac8cb6ab5bc2d50", "141319b1a84827e1046e93741bf8a9a15a916d49684ab04925ac4ce4573eea23", "d54b606094287758dcf19064a8d91c727346aadaa9388732e73c4315b7c606f9", "49030e42ce4152e715a7ddaa10e592f8e61d00f70ef11f48546711f159d985df", "b96761b1e7ebd1e8464a78a98fe52f53ce6035c32b4b2b12307a629a551ff7cf", "d4786e2581571c863c7d12231c3afb6d4cef390c0ac9a24b243293721d28ea95", "ed28e3d3530544f1cf2b43d1956b7bd13b63c612d963a8fb37387aa1a5e11460", "05b127365cf115d4978a7997ee98f9b48f0ddc552b981c18aa2ee1b3e6df42c6", "9d11dd6843f298b01b34bd7f7e4b1037489871531d14b58199b7cba1ac0841e6", "f79e90fa4091de4fc2ec70f5bf67b24393285c112658e0d810e6bd711387fbb9", "99f1fc0f09230ce745b6a256ba7082e6e51a2907abda3d9e735a5c8188bb4ba1", "477f86cce983b9c91a36fdcd4a7ce21144a08dee9b1aafb91b9c70e57f717ce6", "b03d2e6bb4a7d71c66a66ff9e9c93549cae4b593f634a4ea2a1f79f94200f5b4", "9ddc0f53a81e631dcf39d5155f41ec12ed551b731efc3224f410667ba07b37dc", "cf087ff9ae7c9954ad8612d071e5cdf34a6024ee1ae477217639e63a802a53dd", "b64f62b94babb82cc78d3d1308631ae221552bb595202fc1d267e1c29ce7ba60", "a91e24875f8a534497459e5ccb872c4438be3130d8d74b7e1104c5f94cdcf8c2", "4f49f3d029eeeb3fed14d59625acd088b6b34f3b41c527afa09d29e4a7725c32", "179795fd7ac7e7efcba3c36d539a1e8659fb40d77d0a3fab2c25562d99793086", "4ba37d0b40b879eceaaca2802a1635f2e6d86d5c31e3ff2d2fd13e68dd2a6d3d", "6b7f5dfba9cd3108f1410b56f6a84188eee23ab48a3621b209a67eea64293394", "870c540da9fafde331a3316cee50c17ad76ddb9160b78b317bef2e6f6fc4bac0", "470b4cccaea895d8a5820aed088357e380d66b8e7510f0a1ea9b575850160241", "8a55f8942af0aec1e0df3ab328b974a7888ffd60ded48cc6862013da0f41afbc", "2e51e8409f28baf93e665df2a9d646a1bf9ac8703cbf9a6766cfdefa249d5780", "99ef1a23e95910287d39493d8d9d7d1f0b498286f2b1fdbc0b01495f10cf0958", "6652200c53a4551efe2a7541072d817562812003f9d9ef0ec17995aa232378f8", "39c6c01194df72dda97da2072335c38231ced9b39afa280452afcca901e73643", "12097e411d948f77b7b6fa4656c6573481c1b4e2864c1fca9d5b296096707c45", "cbe53bf1976aee6cec830a848c6ac132def1503cffde82ccfe5bd15e75cbaa72", "eeab5dcfff92dbabb7e285445aba47bd5135a4a3502df59ac546847aeb5a964f", "5ea8279a578027abefab9c17cef186cccf000306685e5f2ee78bdf62cae568dd", "0607767d89ad9c7686dbb01b37248290b2fa7364b2bf37d86afd51b88756fe66", "e4fd5f45c08b52dae40f4cdff45e8681e76b5af5761356c4caed4ca750dc65cd", "145b1c82caa2a6d703108444a5cf03e9cb8c3cd3f19299582a564276dbbba734", "736b22ec91ae9b4b2b15e8d8c220f6c152d4f2228f6d46c16e6a9b98b4733120", "ac776cb8b40f92cdd307b16b83e18eeb1fbaa5b5d6bd992b3fda0b4d6de8524c", "65ba30e2202fdf6f37da0f7cfe31dfb5308c9209885aaf4cef4d572fd14e2903", "54e8389455ec2252de063e83d3ce72529d674e6d2dc2070661f01d4f76b63475", "fbbbfb525dd0255ee332d51f59648265aaa20c2e9eff007765cf4d4a6940a849", "8de5e418f34d04f6ea947ce31852092a24a705862e6b810ca9f83c2d5f9cda4d", "ea6040989964f012fd3a92a3170891f5f155430b8bbfa4976cde8d11513b62d9", "14d94547b5deca767137fbd14dae73e888f3516c742fad18b83be333b38f0b88", "47f05203f6368d56158cda2e79167777fc9dcb0c671ef3aabc205a1636c26a29"];
+const latestTime = require("./utils/latestTime.js").latestTime;
+const to8Power = (number) => String(parseFloat(number) * 1e8);
+
+truncNumber = (n) => Math.trunc(n * Math.pow(10, 2)) / Math.pow(10, 2);
+let masterInstance, plotusToken, MockchainLinkInstance, allMarkets;
+
+contract("2 Option market", async function ([user0, user1, user2, user3, user4, user5, userMarketCreator, user6, user7]) {
+    before(async function () {
+        masterInstance = await OwnedUpgradeabilityProxy.deployed();
+        masterInstance = await Master.at(masterInstance.address);
+        plotusToken = await PlotusToken.deployed();
+        MockchainLinkInstance = await MockchainLinkBTC.deployed();
+        allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+        cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+        nullAddress = await masterInstance.getLatestAddress("0x00");
+
+        await plotusToken.transfer(userMarketCreator, toWei(1000));
+        await plotusToken.approve(allMarkets.address, toWei(1000), { from: userMarketCreator });
+        await cyclicMarkets.whitelistMarketCreator(userMarketCreator);
+
+        await cyclicMarkets.setNextOptionPrice(0);
+
+        await MockchainLinkInstance.setLatestAnswer(1195000000000);
+      });
+    describe("Scenario1", async () => {
+      it("0.0", async () => {
+        masterInstance = await OwnedUpgradeabilityProxy.deployed();
+        masterInstance = await Master.at(masterInstance.address);
+        plotusToken = await PlotusToken.deployed();
+        timeNow = await latestTime();
+  
+        allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+        cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+        await increaseTime(5 * 3600);
+        await plotusToken.transfer(user7, toWei(100000));
+        await plotusToken.transfer(user6, toWei(100000));
+        // await plotusToken.transfer(marketIncentives.address,toWei(500));
+  
+        let nullAddress = await masterInstance.getLatestAddress("0x00");
+  
+        await plotusToken.transfer(user6, toWei(100));
+        await plotusToken.approve(allMarkets.address, toWei(200000), { from: user6 });
+        await plotusToken.approve(allMarkets.address, toWei(200000));
+        // await acyclicMarkets.setNextOptionPrice(18);
+        // await acyclicMarkets.claimRelayerRewards();
+        timeNow = await latestTime();
+        let initialLiquidity = 100 * 10 ** 8;
+        // await cyclicMarkets.whitelistMarketCreator(user6);
+        await cyclicMarkets.setNextOptionPrice(0);
+  
+        await MockchainLinkInstance.setLatestAnswer(1195000000000);
+  
+        let cyclicMarketsV3Impl = await CyclicMarkets_3.new();
+        let allMarketsV3Impl = await AllPlotMarkets_4.new();
+        await masterInstance.upgradeMultipleImplementations([toHex("CM"), toHex("AM")], [cyclicMarketsV3Impl.address, allMarketsV3Impl.address]);
+        cyclicMarkets = await CyclicMarkets_3.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+        allMarkets = await AllPlotMarkets_4.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+  
+        let optionPricing2 = await OptionPricing2.new();
+        let optionPricing3 = await OptionPricing3.new();
+        await cyclicMarkets.setOptionPricingContract([2, 3], [optionPricing2.address, optionPricing3.address]);
+        marketStartTime = await latestTime();
+        await cyclicMarkets.newMarketType(2, 15*60, 100, marketStartTime, 60 * 60, 5 * 60, 15 * 60, 100 * 1e8);
+      });
+  
+      it("Should not allow to create buffer market if pre-buffer time is not set", async () => {
+        marketId = await allMarkets.getTotalMarketsLength();
+        await increaseTime(marketStartTime/1 - (await latestTime()));
+        await cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8);
+        await cyclicMarkets.createMarket(0, 3, 0);
+        await increaseTime(10*60);
+        await assertRevert(cyclicMarkets.createMarket(0, 3, 0));
+        await increaseTime(5*60);
+      });
+      
+      it("Pre buffer time should not be greater than prediction time", async() => {
+        await assertRevert(cyclicMarkets.setMarketCreationPreBuffer(3,20*60));
+      });
+
+      it("Set pre buffer time for 15 min market", async() => {
+        await cyclicMarkets.setMarketCreationPreBuffer(3,600);
+        await cyclicMarkets.createMarket(0, 3, 0);
+      });
+
+      it("Should not allow to create buffer market befor pre-buffer times", async () => {
+        await assertRevert(cyclicMarkets.createMarket(0, 3, 0));
+      });
+
+      it("Should allow to create buffer market after pre-buffer time", async () => {
+        await increaseTime(11*60);
+        await cyclicMarkets.createMarket(0, 3, 0);
+      });
+
+      it("Should not allow to create more than one buffer market", async () => {
+        await assertRevert(cyclicMarkets.createMarket(0, 3, 0));
+      });
+
+      it("Set pre buffer time for 3 option market", async() => {
+        await cyclicMarkets.setMarketCreationPreBuffer(0,600);
+        let starttime = await cyclicMarkets.calculateStartTimeForMarket(0,0);
+        await increaseTime((await latestTime())/1 -  starttime*1 + 10);
+        marketId = await allMarkets.getTotalMarketsLength();
+        await cyclicMarkets.createMarket(0, 0, 0);
+        marketData = await allMarkets.getMarketData(marketId);
+        await increaseTime(marketData[3]/1 - await latestTime() - 540);
+      });
+
+      it("Should be able to create buffer market", async() => {
+        await cyclicMarkets.setEarlyParticipantMultiplier(0, 10*60, 10);
+        marketId = await allMarkets.getTotalMarketsLength();
+        await cyclicMarkets.setNextOptionPrice(18);
+        await cyclicMarkets.createMarket(0, 0, 0, { from: userMarketCreator })
+      });
+
+      it("Positions After activating early participant multiplier", async () => {
+        await plotusToken.transfer(user1, toWei("100"));
+        await plotusToken.transfer(user2, toWei("400"));
+        await plotusToken.transfer(user3, toWei("100"));
+        await plotusToken.transfer(user4, toWei("100"));
+        await plotusToken.transfer(user5, toWei("1000"));
+
+        await plotusToken.approve(allMarkets.address, toWei("10000"), { from: user1 });
+        await plotusToken.approve(allMarkets.address, toWei("10000"), { from: user2 });
+        await plotusToken.approve(allMarkets.address, toWei("10000"), { from: user3 });
+        await plotusToken.approve(allMarkets.address, toWei("10000"), { from: user4 });
+        await plotusToken.approve(allMarkets.address, toWei("10000"), { from: user5 });
+
+        assert.equal((await cyclicMarkets.getOptionPrice(marketId, 2)) / 1, 18);
+        functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(100), marketId, plotusToken.address, to8Power("100"), 2);
+        //Should revert if predicted before market creation time
+        await assertRevert(signAndExecuteMetaTx(
+          privateKeyList[1],
+          user1,
+          functionSignature,
+          allMarkets,
+          "AM"
+        ));
+        
+        marketData = await allMarkets.getMarketData(marketId);
+        await increaseTime((marketData[3]/1 - marketData[2]/1) - await latestTime());
+
+        // await increaseTime(9*60 + 1);
+        await increaseTime(2*60);
+        //Predict after 2 minutes of starttime and user should get 1.1X multiplier
+        functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(100), marketId, plotusToken.address, to8Power("100"), 2);
+        await signAndExecuteMetaTx(
+          privateKeyList[1],
+          user1,
+          functionSignature,
+          allMarkets,
+          "AM"
+        );
+        //Predict after 4 minutes of starttime and user should get 1.1X multiplier 
+        await increaseTime(2*60);
+        functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(400), marketId, plotusToken.address, to8Power("400"), 2);
+        await signAndExecuteMetaTx(
+          privateKeyList[2],
+          user2,
+          functionSignature,
+          allMarkets,
+          "AM"
+        );
+
+        await cyclicMarkets.setNextOptionPrice(9);
+        assert.equal((await cyclicMarkets.getOptionPrice(marketId, 1)) / 1, 9);
+        //Predict after 6 minutes of starttime and user should get 1.1X multiplier 
+        await increaseTime(2*60);
+        functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(100), marketId, plotusToken.address, to8Power("100"), 1);
+        await signAndExecuteMetaTx(
+          privateKeyList[3],
+          user3,
+          functionSignature,
+          allMarkets,
+          "AM"
+        );
+
+        //Predict after 20 minutes of starttime and user should not get multiplier 
+        await increaseTime(14*60);
+        await cyclicMarkets.setNextOptionPrice(27);
+        assert.equal((await cyclicMarkets.getOptionPrice(marketId, 3)) / 1, 27);
+        functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(100), marketId, plotusToken.address, to8Power("100"), 3);
+        await signAndExecuteMetaTx(
+          privateKeyList[4],
+          user4,
+          functionSignature,
+          allMarkets,
+          "AM"
+        );
+        //Predict after 30 minutes of starttime and user should not get multiplier 
+        await increaseTime(10*60);
+        functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(1000), marketId, plotusToken.address, to8Power("1000"), 3);
+        await signAndExecuteMetaTx(
+          privateKeyList[5],
+          user5,
+          functionSignature,
+          allMarkets,
+          "AM"
+        );
+        predictionPointsBeforeUser1 = (await allMarkets.getUserPredictionPoints(user1, marketId, 2)) / 1e5;
+        predictionPointsBeforeUser2 = (await allMarkets.getUserPredictionPoints(user2, marketId, 2)) / 1e5;
+        predictionPointsBeforeUser3 = (await allMarkets.getUserPredictionPoints(user3, marketId, 1)) / 1e5;
+        predictionPointsBeforeUser4 = (await allMarkets.getUserPredictionPoints(user4, marketId, 3)) / 1e5;
+        predictionPointsBeforeUser5 = (await allMarkets.getUserPredictionPoints(user5, marketId, 3)) / 1e5;
+        
+        predictionPointsBeforeCreator1 = (await allMarkets.getUserPredictionPoints(userMarketCreator, marketId, 1)/1e5);
+        predictionPointsBeforeCreator2 = (await allMarkets.getUserPredictionPoints(userMarketCreator, marketId, 2)/1e5);
+        predictionPointsBeforeCreator3 = (await allMarkets.getUserPredictionPoints(userMarketCreator, marketId, 3)/1e5);
+        
+        const expectedPredictionPoints = [5988.88888, 23955.55556, 11977.77778, 3629.62963, 36296.2963, 1996.296296, 1996.296296, 1996.296296];
+        const predictionPointArray = [
+            predictionPointsBeforeUser1,
+            predictionPointsBeforeUser2,
+            predictionPointsBeforeUser3,
+            predictionPointsBeforeUser4,
+            predictionPointsBeforeUser5,
+            predictionPointsBeforeCreator1,
+            predictionPointsBeforeCreator2,
+            predictionPointsBeforeCreator3
+        ];
+        for (let i = 0; i < predictionPointArray.length; i++) {
+          try {
+              assert.equal(parseInt(expectedPredictionPoints[i]), parseInt(predictionPointArray[i]));
+            } catch (error) {
+              console.log(`Error at index ${i} : ${parseInt(predictionPointArray[i])}`);
+            }
+          }
+
+        await increaseTime(8 * 60 * 60);
+        let daobalanceBefore = await plotusToken.balanceOf(masterInstance.address);
+        daobalanceBefore = daobalanceBefore*1;
+        await cyclicMarkets.settleMarket(marketId, 2);
+        await increaseTime(8 * 60 * 60);
+        let daobalanceAfter = await plotusToken.balanceOf(masterInstance.address);
+        daobalanceAfter = daobalanceAfter*1;
+        let commission = 0;
+        let daoCommission = 3.5999;
+        assert.equal(Math.trunc(daobalanceAfter/1e15), Math.trunc((((daobalanceBefore/1e14))  + daoCommission*1e4)/10));
+        let creationReward = 14.3999;
+        let balanceBefore = await plotusToken.balanceOf(userMarketCreator);
+        await cyclicMarkets.claimCreationReward({ from: userMarketCreator });
+        let balanceAfter = await plotusToken.balanceOf(userMarketCreator);
+        assert.equal(~~(balanceAfter/1e15), ~~((balanceBefore/1e14  + creationReward*1e4)/10));
+    });
+
+    it("Create a buffer market to check option pricing", async() => {
+        marketStartTime = await latestTime();
+        await cyclicMarkets.newMarketType(3, 4*60*60+1, 100, marketStartTime, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8);
+        await cyclicMarkets.setMarketCreationPreBuffer(4,600);
+        await cyclicMarkets.createMarket(0,4, 0);
+        await increaseTime(4*60*60+1 - 540);
+        await cyclicMarkets.setNextOptionPrice(0);
+        marketId = await allMarkets.getTotalMarketsLength();
+        await cyclicMarkets.createMarket(0,4, 0);
+        await MockchainLinkInstance.setLatestAnswer(1195000000000);
+        let optionPrices = await cyclicMarkets.getAllOptionPrices(marketId);
+        assert.equal(optionPrices[0] / 1, 25000);
+        assert.equal(optionPrices[1] / 1, 50000);
+        assert.equal(optionPrices[2] / 1, 25000);
+        await MockchainLinkInstance.setLatestAnswer(1);
+        optionPrices = await cyclicMarkets.getAllOptionPrices(marketId);
+        assert.equal(optionPrices[0] / 1, 50000);
+        assert.equal(optionPrices[1] / 1, 33333);
+        assert.equal(optionPrices[2] / 1, 16666);
+        await MockchainLinkInstance.setLatestAnswer(1195000000000);
+    });
+    
+    it("1.Scenario 1 - Stake < minstakes and time passed < min time passed", async () => {
+      await increaseTime(540);
+
+      await increaseTime(360);
+
+      await plotusToken.transfer(user2, toWei(10000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+      await allMarkets.depositAndPlacePrediction(toWei(10000), marketId, plotusToken.address, 10000 * 1e8, 1, {from: user2});
+
+      await plotusToken.transfer(user3, toWei(2000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+      await allMarkets.depositAndPlacePrediction(toWei(2000), marketId, plotusToken.address, 2000 * 1e8, 2, {from: user3});
+
+      await plotusToken.transfer(user4, toWei(5000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+      await allMarkets.depositAndPlacePrediction(toWei(5000), marketId, plotusToken.address, 5000 * 1e8, 3, {from: user4});
+
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(marketId);
+      assert.equal(optionPrices[0] / 1, 25000);
+      assert.equal(optionPrices[1] / 1, 50000);
+      assert.equal(optionPrices[2] / 1, 25000);
+      await MockchainLinkInstance.setLatestAnswer(1);
+      optionPrices = await cyclicMarkets.getAllOptionPrices(marketId);
+      assert.equal(optionPrices[0] / 1, 50000);
+      assert.equal(optionPrices[1] / 1, 33333);
+      assert.equal(optionPrices[2] / 1, 16666);
+      await MockchainLinkInstance.setLatestAnswer(1195000000000);
+    });
+
+    it("2.Scenario 2 - Stake > minstakes and time passed < min time passed", async () => {
+
+      let expireT = await allMarkets.getMarketData(marketId);
+      await increaseTime(14401 - 360 -540);
+
+      await cyclicMarkets.createMarket(0, 4, 0);
+      marketId++;
+
+      await increaseTime(540);
+
+
+      await plotusToken.transfer(user2, toWei(10000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+      await allMarkets.depositAndPlacePrediction(toWei(10000), marketId, plotusToken.address, 10000 * 1e8, 1, {from: user2});
+
+      await plotusToken.transfer(user3, toWei(5000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+      await allMarkets.depositAndPlacePrediction(toWei(5000), marketId, plotusToken.address, 5000 * 1e8, 2, {from: user3});
+
+      await plotusToken.transfer(user4, toWei(40000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+      await allMarkets.depositAndPlacePrediction(toWei(40000), marketId, plotusToken.address, 40000 * 1e8, 3, {from: user4});
+
+      let expireTim = await allMarkets.getMarketData(marketId);
+      await increaseTimeTo(expireTim[5] / 1 - 4 * 3600 + 360);
+
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 1)) / 1e5), 0.19);
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 2)) / 1e5), 0.16);
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 3)) / 1e5), 0.63);
+    });
+
+    it("3.Scenario 3 - Stake > minstakes and time passed > min time passed", async () => {
+
+      let expireT = await allMarkets.getMarketData(8);
+
+      await increaseTime(14401 - 360 - 540);
+
+      await assertRevert(allMarkets.postMarketResult(7, 10000000000));
+
+      await cyclicMarkets.createMarket(0, 0, 3);
+      marketId++;
+
+      await increaseTime(540);
+
+      await plotusToken.transfer(user2, toWei(10000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+      await allMarkets.depositAndPlacePrediction(toWei(10000), marketId, plotusToken.address, 10000 * 1e8, 1, {from: user2});
+
+      await plotusToken.transfer(user3, toWei(5000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+      await allMarkets.depositAndPlacePrediction(toWei(5000), marketId, plotusToken.address, 5000 * 1e8, 2, {from: user3});
+
+      await plotusToken.transfer(user4, toWei(40000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+      await allMarkets.depositAndPlacePrediction(toWei(40000), marketId, plotusToken.address, 40000 * 1e8, 3, {from: user4});
+
+      let expireTim = await allMarkets.getMarketData(marketId);
+      await increaseTimeTo(expireTim[3] / 1 - 4 * 3600 + 41 * 60);
+
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 1)) / 1e5), 0.19);
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 2)) / 1e5), 0.16);
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 3)) / 1e5), 0.63);
+    });
+
+    it("4.Scenario 4 - Stake > minstakes and time passed > min time passed max distance = 2", async () => {
+      let expireT = await allMarkets.getMarketData(9);
+
+      await increaseTime(14401 - 41*60 - 540);
+
+      await cyclicMarkets.createMarket(0, 0, 3);
+      marketId++;
+      await increaseTime(540);
+
+      await plotusToken.transfer(user2, toWei(10000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+      await allMarkets.depositAndPlacePrediction(toWei(10000), marketId, plotusToken.address, 10000 * 1e8, 1, {from: user2});
+
+      await plotusToken.transfer(user3, toWei(5000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+      await allMarkets.depositAndPlacePrediction(toWei(5000), marketId, plotusToken.address, 5000 * 1e8, 2, {from: user3});
+
+      await plotusToken.transfer(user4, toWei(40000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+      await allMarkets.depositAndPlacePrediction(toWei(40000), marketId, plotusToken.address, 40000 * 1e8, 3, {from: user4});
+
+      await MockchainLinkInstance.setLatestAnswer(1222000000000);
+
+      let expireTim = await allMarkets.getMarketData(marketId);
+      await increaseTimeTo(expireTim[5] / 1 - 4 * 3600 + 41 * 60);
+
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 1)) / 1e5), 0.17);
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 2)) / 1e5), 0.13);
+      assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(marketId, 3)) / 1e5), 0.68);
+    });
+
+      // it("Should revert if try to fetch option price for invalid marketId", async () => {
+      // 	await assertRevert(cyclicMarkets.getAllOptionPrices(2)); // marketId 2 is cyclic market
+      // });
+  
+    });
+  });

--- a/test/VariableOptionsShorterMarkets.test.js
+++ b/test/VariableOptionsShorterMarkets.test.js
@@ -29,6 +29,7 @@ contract("Market", async function ([user1, user2, user3, user4]) {
     MockchainLinkInstance = await MockchainLinkBTC.deployed();
     allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
     cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+    nullAddress = await masterInstance.getLatestAddress("0x00");
 
     await cyclicMarkets.setNextOptionPrice(0);
 
@@ -90,6 +91,11 @@ contract("Market", async function ([user1, user2, user3, user4]) {
 
       let optionPricing3 = await OptionPricing3.new();
       await cyclicMarkets.setOptionPricingContract([3], [optionPricing3.address]);
+      await assertRevert(cyclicMarkets.setOptionPricingContract([3,4], [optionPricing3.address]));
+      await assertRevert(cyclicMarkets.setOptionPricingContract([2], [optionPricing3.address]));
+      await assertRevert(cyclicMarkets.setOptionPricingContract([1], [optionPricing3.address]));
+      await assertRevert(cyclicMarkets.setOptionPricingContract([3], [nullAddress]));
+      await assertRevert(cyclicMarkets.updateMarketType(0, 100, 60 * 60, 40 * 60, 120 * 1e8));
       await cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8);
     });
 
@@ -172,6 +178,12 @@ contract("Market", async function ([user1, user2, user3, user4]) {
 
       let optionPricing3 = await OptionPricing3.new();
       await cyclicMarkets.setOptionPricingContract([3], [optionPricing3.address]);
+      await assertRevert(cyclicMarkets.alterMarketType(0, 4, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8));
+      await assertRevert(cyclicMarkets.alterMarketType(0, 3, 0, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8));
+      await assertRevert(cyclicMarkets.alterMarketType(0, 3, 100, 0, 60 * 60, 40 * 60, 120 * 1e8));
+      await assertRevert(cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 0, 40 * 60, 120 * 1e8));
+      await assertRevert(cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 0, 120 * 1e8));
+      await assertRevert(cyclicMarkets.alterMarketType(10, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120*1e8));
       await cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8);
     });
 
@@ -438,7 +450,7 @@ contract("2 Option market", async function (users) {
       await plotusToken.transfer(users[11], toWei(100000));
       // await plotusToken.transfer(marketIncentives.address,toWei(500));
 
-      let nullAddress = "0x0000000000000000000000000000";
+      let nullAddress = await masterInstance.getLatestAddress("0x00");
 
       await plotusToken.transfer(users[11], toWei(100));
       await plotusToken.approve(allMarkets.address, toWei(200000), { from: users[11] });
@@ -459,6 +471,14 @@ contract("2 Option market", async function (users) {
       let optionPricing2 = await OptionPricing2.new();
       let optionPricing3 = await OptionPricing3.new();
       await cyclicMarkets.setOptionPricingContract([2, 3], [optionPricing2.address, optionPricing3.address]);
+      await assertRevert(cyclicMarkets.addMarketType(4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 60 * 60, 40 * 60, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(2, 4 * 60 * 60, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(2, 0, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(2, 4 * 60 * 61, 0, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(2, 4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 0, 40 * 60, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(2, 4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 0, 60 * 60, 40 * 60, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(2, 4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 0, 100 * 1e8));
+      await assertRevert(cyclicMarkets.newMarketType(4, 4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8));
       await cyclicMarkets.newMarketType(2, 4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8);
     });
 

--- a/test/VariableOptionsShorterMarkets.test.js
+++ b/test/VariableOptionsShorterMarkets.test.js
@@ -104,7 +104,21 @@ contract("Market", async function ([user1, user2, user3, user4]) {
       assert.equal(optionPrices[0] / 1, 25000);
       assert.equal(optionPrices[1] / 1, 50000);
       assert.equal(optionPrices[2] / 1, 25000);
-    })
+    });
+
+    it("Should not allow to create when previous market is live", async () => {
+      await assertRevert(cyclicMarkets.createMarket(0,0,0));
+    });
+
+    it("Creating a market will not settle previous markets", async() => {
+      await increaseTime(4*60*60);
+      await cyclicMarkets.createMarket(0, 0, 1);
+      await increaseTime(4*60*60);
+      await cyclicMarkets.createMarket(0, 0, 1);
+      assert.equal((await allMarkets.marketStatus(7))/1, 1);
+      await cyclicMarkets.settleMarket(7,1);
+      assert.equal((await allMarkets.marketStatus(7))/1, 2);
+    });
 
   });
 });

--- a/test/VariableOptionsShorterMarkets.test.js
+++ b/test/VariableOptionsShorterMarkets.test.js
@@ -362,10 +362,6 @@ contract("3 Option market", async function ([user1, user2, user3, user4]) {
     let expireTim = await allMarkets.getMarketData(9);
     await increaseTimeTo(expireTim[3] / 1 - 4 * 3600 + 41 * 60);
 
-    console.log(expireTim[2] / 1);
-    console.log((await allMarkets.getMarketOptionPricingParams(9, 1))[1] / 1);
-    console.log(await latestTime());
-
     // let optionPricePaams = await allMarkets.getMarketOptionPricingParams(9,1);
     // await increaseTimeTo(optionPricePaams[1]/1+41*60);
 

--- a/test/VariableOptionsShorterMarkets.test.js
+++ b/test/VariableOptionsShorterMarkets.test.js
@@ -1,0 +1,541 @@
+const assertRevert = require("./utils/assertRevert.js").assertRevert;
+const { assert } = require("chai");
+const OwnedUpgradeabilityProxy = artifacts.require("OwnedUpgradeabilityProxy");
+const Master = artifacts.require("Master");
+const PlotusToken = artifacts.require("MockPLOT");
+const MockchainLinkBTC = artifacts.require("MockChainLinkAggregator");
+const AllMarkets = artifacts.require("MockAllMarkets");
+const CyclicMarkets = artifacts.require("MockCyclicMarkets");
+const CyclicMarkets_3 = artifacts.require("CyclicMarkets_3");
+const OptionPricing2 = artifacts.require("OptionPricing2");
+const OptionPricing3 = artifacts.require("OptionPricing3");
+const increaseTime = require("./utils/increaseTime.js").increaseTime;
+const increaseTimeTo = require("./utils/increaseTime.js").increaseTimeTo;
+const { encode3 } = require("./utils/encoder.js");
+const signAndExecuteMetaTx = require("./utils/signAndExecuteMetaTx.js").signAndExecuteMetaTx;
+const { toHex, toWei, toChecksumAddress } = require("./utils/ethTools");
+let privateKeyList = ["fb437e3e01939d9d4fef43138249f23dc1d0852e69b0b5d1647c087f869fabbd", "7c85a1f1da3120c941b83d71a154199ee763307683f206b98ad92c3b4e0af13e", "ecc9b35bf13bd5459350da564646d05c5664a7476fe5acdf1305440f88ed784c", "f4470c3fca4dbef1b2488d016fae25978effc586a1f83cb29ac8cb6ab5bc2d50", "141319b1a84827e1046e93741bf8a9a15a916d49684ab04925ac4ce4573eea23", "d54b606094287758dcf19064a8d91c727346aadaa9388732e73c4315b7c606f9", "49030e42ce4152e715a7ddaa10e592f8e61d00f70ef11f48546711f159d985df", "b96761b1e7ebd1e8464a78a98fe52f53ce6035c32b4b2b12307a629a551ff7cf", "d4786e2581571c863c7d12231c3afb6d4cef390c0ac9a24b243293721d28ea95", "ed28e3d3530544f1cf2b43d1956b7bd13b63c612d963a8fb37387aa1a5e11460", "05b127365cf115d4978a7997ee98f9b48f0ddc552b981c18aa2ee1b3e6df42c6", "9d11dd6843f298b01b34bd7f7e4b1037489871531d14b58199b7cba1ac0841e6", "f79e90fa4091de4fc2ec70f5bf67b24393285c112658e0d810e6bd711387fbb9", "99f1fc0f09230ce745b6a256ba7082e6e51a2907abda3d9e735a5c8188bb4ba1", "477f86cce983b9c91a36fdcd4a7ce21144a08dee9b1aafb91b9c70e57f717ce6", "b03d2e6bb4a7d71c66a66ff9e9c93549cae4b593f634a4ea2a1f79f94200f5b4", "9ddc0f53a81e631dcf39d5155f41ec12ed551b731efc3224f410667ba07b37dc", "cf087ff9ae7c9954ad8612d071e5cdf34a6024ee1ae477217639e63a802a53dd", "b64f62b94babb82cc78d3d1308631ae221552bb595202fc1d267e1c29ce7ba60", "a91e24875f8a534497459e5ccb872c4438be3130d8d74b7e1104c5f94cdcf8c2", "4f49f3d029eeeb3fed14d59625acd088b6b34f3b41c527afa09d29e4a7725c32", "179795fd7ac7e7efcba3c36d539a1e8659fb40d77d0a3fab2c25562d99793086", "4ba37d0b40b879eceaaca2802a1635f2e6d86d5c31e3ff2d2fd13e68dd2a6d3d", "6b7f5dfba9cd3108f1410b56f6a84188eee23ab48a3621b209a67eea64293394", "870c540da9fafde331a3316cee50c17ad76ddb9160b78b317bef2e6f6fc4bac0", "470b4cccaea895d8a5820aed088357e380d66b8e7510f0a1ea9b575850160241", "8a55f8942af0aec1e0df3ab328b974a7888ffd60ded48cc6862013da0f41afbc", "2e51e8409f28baf93e665df2a9d646a1bf9ac8703cbf9a6766cfdefa249d5780", "99ef1a23e95910287d39493d8d9d7d1f0b498286f2b1fdbc0b01495f10cf0958", "6652200c53a4551efe2a7541072d817562812003f9d9ef0ec17995aa232378f8", "39c6c01194df72dda97da2072335c38231ced9b39afa280452afcca901e73643", "12097e411d948f77b7b6fa4656c6573481c1b4e2864c1fca9d5b296096707c45", "cbe53bf1976aee6cec830a848c6ac132def1503cffde82ccfe5bd15e75cbaa72", "eeab5dcfff92dbabb7e285445aba47bd5135a4a3502df59ac546847aeb5a964f", "5ea8279a578027abefab9c17cef186cccf000306685e5f2ee78bdf62cae568dd", "0607767d89ad9c7686dbb01b37248290b2fa7364b2bf37d86afd51b88756fe66", "e4fd5f45c08b52dae40f4cdff45e8681e76b5af5761356c4caed4ca750dc65cd", "145b1c82caa2a6d703108444a5cf03e9cb8c3cd3f19299582a564276dbbba734", "736b22ec91ae9b4b2b15e8d8c220f6c152d4f2228f6d46c16e6a9b98b4733120", "ac776cb8b40f92cdd307b16b83e18eeb1fbaa5b5d6bd992b3fda0b4d6de8524c", "65ba30e2202fdf6f37da0f7cfe31dfb5308c9209885aaf4cef4d572fd14e2903", "54e8389455ec2252de063e83d3ce72529d674e6d2dc2070661f01d4f76b63475", "fbbbfb525dd0255ee332d51f59648265aaa20c2e9eff007765cf4d4a6940a849", "8de5e418f34d04f6ea947ce31852092a24a705862e6b810ca9f83c2d5f9cda4d", "ea6040989964f012fd3a92a3170891f5f155430b8bbfa4976cde8d11513b62d9", "14d94547b5deca767137fbd14dae73e888f3516c742fad18b83be333b38f0b88", "47f05203f6368d56158cda2e79167777fc9dcb0c671ef3aabc205a1636c26a29"];
+const latestTime = require("./utils/latestTime.js").latestTime;
+
+truncNumber = (n) => Math.trunc(n * Math.pow(10, 2)) / Math.pow(10, 2);
+let masterInstance, plotusToken, MockchainLinkInstance, allMarkets;
+
+contract("Market", async function ([user1, user2, user3, user4]) {
+
+  before(async function () {
+    masterInstance = await OwnedUpgradeabilityProxy.deployed();
+    masterInstance = await Master.at(masterInstance.address);
+    plotusToken = await PlotusToken.deployed();
+    MockchainLinkInstance = await MockchainLinkBTC.deployed();
+    allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+    cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+    await cyclicMarkets.setNextOptionPrice(0);
+
+    await MockchainLinkInstance.setLatestAnswer(1195000000000);
+  });
+
+  describe("Live markets should not be affected if contract is upgraded", async () => {
+    it("1.Scenario 1 - Stake < minstakes and time passed < min time passed", async () => {
+
+      let expireT = await allMarkets.getMarketData(1);
+      await increaseTime(14400 + expireT[3] / 1 - await latestTime());
+
+      await cyclicMarkets.createMarket(0, 0, 0);
+      await increaseTime(360);
+
+
+      await plotusToken.transfer(user2, toWei(10000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+      let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(10000), 7, plotusToken.address, 10000 * 1e8, 1);
+      await signAndExecuteMetaTx(
+        privateKeyList[1],
+        user2,
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      await plotusToken.transfer(user3, toWei(2000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+      functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(2000), 7, plotusToken.address, 2000 * 1e8, 2);
+      await signAndExecuteMetaTx(
+        privateKeyList[2],
+        user3,
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      await plotusToken.transfer(user4, toWei(5000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+      functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(5000), 7, plotusToken.address, 5000 * 1e8, 3);
+      await signAndExecuteMetaTx(
+        privateKeyList[3],
+        user4,
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+      assert.equal(optionPrices[0] / 1, 25000);
+      assert.equal(optionPrices[1] / 1, 50000);
+      assert.equal(optionPrices[2] / 1, 25000);
+    });
+
+    it("Upgrade contract and Add option pricing contracts and update market type", async () => {
+      let cyclicMarketsV3Impl = await CyclicMarkets_3.new();
+      await masterInstance.upgradeMultipleImplementations([toHex("CM")], [cyclicMarketsV3Impl.address]);
+      cyclicMarkets = await CyclicMarkets_3.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+      let optionPricing3 = await OptionPricing3.new();
+      await cyclicMarkets.setOptionPricingContract([3], [optionPricing3.address]);
+      await cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8);
+    });
+
+    it("Option pricing should work as expected", async () => {
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+      assert.equal(optionPrices[0] / 1, 25000);
+      assert.equal(optionPrices[1] / 1, 50000);
+      assert.equal(optionPrices[2] / 1, 25000);
+    })
+
+  });
+});
+
+contract("Market", async function ([user1, user2, user3, user4]) {
+
+  before(async function () {
+    masterInstance = await OwnedUpgradeabilityProxy.deployed();
+    masterInstance = await Master.at(masterInstance.address);
+    plotusToken = await PlotusToken.deployed();
+    MockchainLinkInstance = await MockchainLinkBTC.deployed();
+    allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+    cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+    await cyclicMarkets.setNextOptionPrice(0);
+    await MockchainLinkInstance.setLatestAnswer(1195000000000);
+
+    let expireT = await allMarkets.getMarketData(1);
+    await increaseTime(14400 + expireT[3] / 1 - await latestTime());
+    await cyclicMarkets.createMarket(0, 0, 0);
+    await increaseTime(360);
+
+    let cyclicMarketsV3Impl = await CyclicMarkets_3.new();
+    await masterInstance.upgradeMultipleImplementations([toHex("CM")], [cyclicMarketsV3Impl.address]);
+    cyclicMarkets = await CyclicMarkets_3.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+  });
+
+  describe("Contract upgraded and option pricing contracts are not set", async () => {
+    it("1.Scenario 1 - Stake < minstakes and time passed < min time passed", async () => {
+
+      await plotusToken.transfer(user2, toWei(10000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+      let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(10000), 7, plotusToken.address, 10000 * 1e8, 1);
+      await signAndExecuteMetaTx(
+        privateKeyList[1],
+        user2,
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      await plotusToken.transfer(user3, toWei(2000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+      functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(2000), 7, plotusToken.address, 2000 * 1e8, 2);
+      await signAndExecuteMetaTx(
+        privateKeyList[2],
+        user3,
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      await plotusToken.transfer(user4, toWei(5000));
+      await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+      functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(5000), 7, plotusToken.address, 5000 * 1e8, 3);
+      await signAndExecuteMetaTx(
+        privateKeyList[3],
+        user4,
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+      assert.equal(optionPrices[0] / 1, 25000);
+      assert.equal(optionPrices[1] / 1, 50000);
+      assert.equal(optionPrices[2] / 1, 25000);
+    });
+
+    it("Add option pricing contracts and update market type", async () => {
+
+      let optionPricing3 = await OptionPricing3.new();
+      await cyclicMarkets.setOptionPricingContract([3], [optionPricing3.address]);
+      await cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8);
+    });
+
+    it("Option pricing should work as expected", async () => {
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+      assert.equal(optionPrices[0] / 1, 25000);
+      assert.equal(optionPrices[1] / 1, 50000);
+      assert.equal(optionPrices[2] / 1, 25000);
+    })
+
+  });
+});
+
+contract("3 Option market", async function ([user1, user2, user3, user4]) {
+
+  before(async function () {
+    masterInstance = await OwnedUpgradeabilityProxy.deployed();
+    masterInstance = await Master.at(masterInstance.address);
+    plotusToken = await PlotusToken.deployed();
+    MockchainLinkInstance = await MockchainLinkBTC.deployed();
+    allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+    cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+    await cyclicMarkets.setNextOptionPrice(0);
+
+    await MockchainLinkInstance.setLatestAnswer(1195000000000);
+
+    let cyclicMarketsV3Impl = await CyclicMarkets_3.new();
+    await masterInstance.upgradeMultipleImplementations([toHex("CM")], [cyclicMarketsV3Impl.address]);
+    cyclicMarkets = await CyclicMarkets_3.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+    let optionPricing2 = await OptionPricing2.new();
+    let optionPricing3 = await OptionPricing3.new();
+    await cyclicMarkets.setOptionPricingContract([2, 3], [optionPricing2.address, optionPricing3.address]);
+    await cyclicMarkets.alterMarketType(0, 3, 100, 8 * 60 * 60, 60 * 60, 40 * 60, 120 * 1e8);
+  });
+
+  it("1.Scenario 1 - Stake < minstakes and time passed < min time passed", async () => {
+
+    let expireT = await allMarkets.getMarketData(1);
+    await increaseTime(14400 + expireT[3] / 1 - await latestTime());
+
+    await cyclicMarkets.createMarket(0, 0, 0);
+    await increaseTime(360);
+
+
+    await plotusToken.transfer(user2, toWei(10000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+    let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(10000), 7, plotusToken.address, 10000 * 1e8, 1);
+    await signAndExecuteMetaTx(
+      privateKeyList[1],
+      user2,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user3, toWei(2000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(2000), 7, plotusToken.address, 2000 * 1e8, 2);
+    await signAndExecuteMetaTx(
+      privateKeyList[2],
+      user3,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user4, toWei(5000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(5000), 7, plotusToken.address, 5000 * 1e8, 3);
+    await signAndExecuteMetaTx(
+      privateKeyList[3],
+      user4,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+    let optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+    assert.equal(optionPrices[0] / 1, 25000);
+    assert.equal(optionPrices[1] / 1, 50000);
+    assert.equal(optionPrices[2] / 1, 25000);
+    await MockchainLinkInstance.setLatestAnswer(1);
+    optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+    assert.equal(optionPrices[0] / 1, 50000);
+    assert.equal(optionPrices[1] / 1, 33333);
+    assert.equal(optionPrices[2] / 1, 16666);
+    await MockchainLinkInstance.setLatestAnswer(1195000000000);
+  });
+
+  it("2.Scenario 2 - Stake > minstakes and time passed < min time passed", async () => {
+
+
+    let expireT = await allMarkets.getMarketData(7);
+    await increaseTime(14400 + expireT[3] / 1 - await latestTime());
+
+    await cyclicMarkets.createMarket(0, 0, 3);
+
+
+
+    await plotusToken.transfer(user2, toWei(10000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+    let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(10000), 8, plotusToken.address, 10000 * 1e8, 1);
+    await signAndExecuteMetaTx(
+      privateKeyList[1],
+      user2,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user3, toWei(5000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(5000), 8, plotusToken.address, 5000 * 1e8, 2);
+    await signAndExecuteMetaTx(
+      privateKeyList[2],
+      user3,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user4, toWei(40000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(40000), 8, plotusToken.address, 40000 * 1e8, 3);
+    await signAndExecuteMetaTx(
+      privateKeyList[3],
+      user4,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    let expireTim = await allMarkets.getMarketData(8);
+    await increaseTimeTo(expireTim[5] / 1 - 4 * 3600 + 360);
+
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(8, 1)) / 1e5), 0.19);
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(8, 2)) / 1e5), 0.16);
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(8, 3)) / 1e5), 0.63);
+  });
+
+  it("3.Scenario 3 - Stake > minstakes and time passed > min time passed", async () => {
+
+    let expireT = await allMarkets.getMarketData(8);
+
+    await increaseTime(14400 + expireT[3] / 1 - await latestTime());
+
+    await assertRevert(allMarkets.postMarketResult(7, 10000000000));
+
+    await cyclicMarkets.createMarket(0, 0, 3);
+
+
+    await plotusToken.transfer(user2, toWei(10000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+    let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(10000), 9, plotusToken.address, 10000 * 1e8, 1);
+    await signAndExecuteMetaTx(
+      privateKeyList[1],
+      user2,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user3, toWei(5000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(5000), 9, plotusToken.address, 5000 * 1e8, 2);
+    await signAndExecuteMetaTx(
+      privateKeyList[2],
+      user3,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user4, toWei(40000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(40000), 9, plotusToken.address, 40000 * 1e8, 3);
+    await signAndExecuteMetaTx(
+      privateKeyList[3],
+      user4,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+
+
+    let expireTim = await allMarkets.getMarketData(9);
+    await increaseTimeTo(expireTim[3] / 1 - 4 * 3600 + 41 * 60);
+
+    console.log(expireTim[2] / 1);
+    console.log((await allMarkets.getMarketOptionPricingParams(9, 1))[1] / 1);
+    console.log(await latestTime());
+
+    // let optionPricePaams = await allMarkets.getMarketOptionPricingParams(9,1);
+    // await increaseTimeTo(optionPricePaams[1]/1+41*60);
+
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(9, 1)) / 1e5), 0.19);
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(9, 2)) / 1e5), 0.16);
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(9, 3)) / 1e5), 0.63);
+  });
+
+  it("4.Scenario 4 - Stake > minstakes and time passed > min time passed max distance = 2", async () => {
+    let expireT = await allMarkets.getMarketData(9);
+
+    await increaseTime(14400 + expireT[3] / 1 - await latestTime());
+
+    await cyclicMarkets.createMarket(0, 0, 3);
+
+    await plotusToken.transfer(user2, toWei(10000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user2 });
+    let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(10000), 10, plotusToken.address, 10000 * 1e8, 1);
+    await signAndExecuteMetaTx(
+      privateKeyList[1],
+      user2,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user3, toWei(5000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user3 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(5000), 10, plotusToken.address, 5000 * 1e8, 2);
+    await signAndExecuteMetaTx(
+      privateKeyList[2],
+      user3,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+
+    await plotusToken.transfer(user4, toWei(40000));
+    await plotusToken.approve(allMarkets.address, toWei(100000), { from: user4 });
+    functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(40000), 10, plotusToken.address, 40000 * 1e8, 3);
+    await signAndExecuteMetaTx(
+      privateKeyList[3],
+      user4,
+      functionSignature,
+      allMarkets,
+      "AM"
+    );
+    await MockchainLinkInstance.setLatestAnswer(1222000000000);
+    // let optionPricePaams = await allMarkets.getMarketOptionPricingParams(10,1);
+    // await increaseTimeTo(optionPricePaams[1]/1+41*60);
+
+    let expireTim = await allMarkets.getMarketData(10);
+    await increaseTimeTo(expireTim[5] / 1 - 4 * 3600 + 41 * 60);
+
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(10, 1)) / 1e5), 0.17);
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(10, 2)) / 1e5), 0.13);
+    assert.equal(truncNumber((await cyclicMarkets.getOptionPrice(10, 3)) / 1e5), 0.68);
+  });
+
+});
+
+contract("2 Option market", async function (users) {
+  describe("Scenario1", async () => {
+    it("0.0", async () => {
+      masterInstance = await OwnedUpgradeabilityProxy.deployed();
+      masterInstance = await Master.at(masterInstance.address);
+      plotusToken = await PlotusToken.deployed();
+      timeNow = await latestTime();
+
+      allMarkets = await AllMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("AM")));
+      cyclicMarkets = await CyclicMarkets.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+      await increaseTime(5 * 3600);
+      await plotusToken.transfer(users[12], toWei(100000));
+      await plotusToken.transfer(users[11], toWei(100000));
+      // await plotusToken.transfer(marketIncentives.address,toWei(500));
+
+      let nullAddress = "0x0000000000000000000000000000";
+
+      await plotusToken.transfer(users[11], toWei(100));
+      await plotusToken.approve(allMarkets.address, toWei(200000), { from: users[11] });
+      await plotusToken.approve(allMarkets.address, toWei(200000));
+      // await acyclicMarkets.setNextOptionPrice(18);
+      // await acyclicMarkets.claimRelayerRewards();
+      timeNow = await latestTime();
+      let initialLiquidity = 100 * 10 ** 8;
+      // await cyclicMarkets.whitelistMarketCreator(users[11]);
+      await cyclicMarkets.setNextOptionPrice(0);
+
+      await MockchainLinkInstance.setLatestAnswer(1195000000000);
+
+      let cyclicMarketsV3Impl = await CyclicMarkets_3.new();
+      await masterInstance.upgradeMultipleImplementations([toHex("CM")], [cyclicMarketsV3Impl.address]);
+      cyclicMarkets = await CyclicMarkets_3.at(await masterInstance.getLatestAddress(web3.utils.toHex("CM")));
+
+      let optionPricing2 = await OptionPricing2.new();
+      let optionPricing3 = await OptionPricing3.new();
+      await cyclicMarkets.setOptionPricingContract([2, 3], [optionPricing2.address, optionPricing3.address]);
+      await cyclicMarkets.newMarketType(2, 4 * 60 * 61, 100, Math.trunc(Date.now() / 1000), 8 * 60 * 60, 60 * 60, 40 * 60, 100 * 1e8);
+    });
+
+    it("Scenario 1: Option price for Market Creator", async () => {
+      timeNow = await latestTime();
+      await cyclicMarkets.createMarket(0, 3, 0);
+      assert.equal(await cyclicMarkets.getOptionPrice(7, 1), 50000);
+      assert.equal(await cyclicMarkets.getOptionPrice(7, 2), 50000);
+      // assert.equal(await allMarkets.getUserPredictionPoints(users[11],7,1),Math.floor(300*1e8/3*0.98/50000)); // post deduction stake = 98 , option price = 1/3 ~0.33333
+      // assert.equal(await allMarkets.getUserPredictionPoints(users[11],7,2),Math.floor(300*1e8/3*0.98/50000)); // post deduction stake = 98 , option price = 1/3 ~0.33333
+    });
+
+    it("Scenario 2: Option price when total stake < minstake", async () => {
+      let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(9900), 7, plotusToken.address, 9900 * 1e8, 1);
+      await signAndExecuteMetaTx(
+        privateKeyList[0],
+        users[0],
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+      functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(8900), 7, plotusToken.address, 8900 * 1e8, 2);
+      await signAndExecuteMetaTx(
+        privateKeyList[0],
+        users[0],
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(7);
+
+      assert.equal(optionPrices[0], 50000); // 1/3
+      assert.equal(optionPrices[1], 50000); // 1/3
+    });
+
+    it("Scenario 3: Option price when total stake > minstake", async () => {
+      await increaseTime(4 * 60 * 61);
+      await cyclicMarkets.createMarket(0, 3, 0);
+      let functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(9950), 8, plotusToken.address, 9950 * 1e8, 1);
+      await signAndExecuteMetaTx(
+        privateKeyList[0],
+        users[0],
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      functionSignature = encode3("depositAndPlacePrediction(uint,uint,address,uint64,uint256)", toWei(13950), 8, plotusToken.address, 13950 * 1e8, 2);
+      await signAndExecuteMetaTx(
+        privateKeyList[0],
+        users[0],
+        functionSignature,
+        allMarkets,
+        "AM"
+      );
+
+      let optionPriceData1 = await allMarkets.getMarketOptionPricingParams(8, 1);
+      let optionPriceData2 = await allMarkets.getMarketOptionPricingParams(8, 2);
+      // assert.equal(optionPriceData1[0][1]/1, 23520*1e8);
+      assert.equal(optionPriceData1[0][0] / 1, 9800 * 1e8);
+      assert.equal(optionPriceData2[0][0] / 1, 13720 * 1e8);
+
+
+      let optionPrices = await cyclicMarkets.getAllOptionPrices(8);
+
+      assert.equal(optionPrices[0] / 1, 41666); // 9800/23520
+      assert.equal(optionPrices[1] / 1, 58333); // 8820/23520
+    });
+
+    // it("Should revert if try to fetch option price for invalid marketId", async () => {
+    // 	await assertRevert(cyclicMarkets.getAllOptionPrices(2)); // marketId 2 is cyclic market
+    // });
+
+  });
+});


### PR DESCRIPTION
### Changes
- Set different option length per market type.
- Option creation and pricing to be managed in separate contracts.
- Configurable settlement time.
- Removed dependency of settling penultimate market for creating a new one.  
- Create Buffer markets within pre-buffer time.
- - Option ranges will be calculated based on the time the transaction was sent for creating buffer markets

### Contract Upgrades
- CyclicMarkets => CyclicMarkets_3
- AllPlotMarkets => AllPlotMarkets_4
### New Contracts
- OptionPricing2 => Contract to manage option pricing for 2 option markets
- OptionPricing3 => Contract to manage option pricing for 3 option markets